### PR TITLE
Update README to redirect issues to slackapi/bolt-js

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ npm run ngrok
 npm run start
 ```
 
+## Contributing
+
+### Issues and questions
+
+Found a bug or have a question about this project? We'd love to hear from you!
+
+1. Browse to [slackapi/bolt-js/issues][4]
+1. Create a new issue
+1. Select the `[x] examples` category
+
+See you there and thanks for helping to improve Bolt for everyone!
+
 [1]: https://slack.dev/bolt-js/tutorial/getting-started
 [2]: https://slack.dev/bolt-js/
 [3]: https://slack.dev/bolt-js/tutorial/getting-started#setting-up-events
+[4]: https://github.com/slackapi/bolt-js/issues/new


### PR DESCRIPTION
This pull request updates the README.md to redirect issues to slackapi/bolt-js. We've decided to consolidate the getting started app's issue tracker with Bolt JS because:

* Bolt JS already has an examples directory and issue label
* Issues to this Getting Started app may overlap with Bolt JS's examples directory
* Fewer issue trackers is easier allows our small team to offer a higher quality support experience