### PR TITLE
Add GitHub maintainers guide, contributors guide, and pull request template

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -1,0 +1,62 @@
+# Contributors Guide
+
+Interested in contributing? Awesome! Before you do though, please read our
+[Code of Conduct](https://slackhq.github.io/code-of-conduct). We take it very seriously, and expect that you will as
+well.
+
+There are many ways you can contribute! :heart:
+
+### Bug Reports and Fixes :bug:
+-  If you find a bug, please search for it in the [Issues](https://github.com/slackapi/bolt-js/issues), and if it isn't already tracked,
+   [create a new issue](https://github.com/slackapi/bolt-js/issues/new). Fill out the "Bug Report" section of the issue template. Even if an Issue is closed, feel free to comment and add details, it will still
+   be reviewed.
+-  Issues that have already been identified as a bug (note: able to reproduce) will be labelled `bug`.
+-  Issues that are related to the examples apps will be labelled `area:examples`.
+-  If you'd like to submit a fix for a bug, [send a Pull Request](#creating_a_pull_request) and mention the Issue number.
+  -  Include tests that isolate the bug and verifies that it was fixed.
+
+### New Features :bulb:
+-  If you'd like to add new functionality to this project, describe the problem you want to solve in a [new Issue](https://github.com/slackapi/bolt-js/issues/new).
+-  Issues that have been identified as a feature request will be labelled `enhancement`.
+-  Issues that are related to the examples apps will be labelled `area:examples`.
+-  If you'd like to implement the new feature, please wait for feedback from the project
+   maintainers before spending too much time writing the code. In some cases, `enhancement`s may
+   not align well with the project objectives at the time.
+
+### Tests :mag:, Documentation :books:, Miscellaneous :sparkles:
+-  If you'd like to improve the tests, you want to make the documentation clearer, you have an
+   alternative implementation of something that may have advantages over the way its currently
+   done, or you have any other change, we would be happy to hear about it!
+  -  If its a trivial change, go ahead and [send a Pull Request](#creating_a_pull_request) with the changes you have in mind.
+  -  If not, [open an Issue](https://github.com/slackapi/bolt-js/issues/new) to discuss the idea first.
+
+If you're new to our project and looking for some way to make your first contribution, look for
+Issues labelled `good first contribution`.
+
+## Requirements
+
+For your contribution to be accepted:
+
+- [x] You must have signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/slackapi/bolt-js-getting-started-app).
+- [x] The test suite must be complete and pass.
+- [x] The changes must be approved by code review.
+- [x] Commits should be atomic and messages must be descriptive. Related issues should be mentioned by Issue number.
+
+If the contribution doesn't meet the above criteria, you may fail our automated checks or a maintainer will discuss it with you. You can continue to improve a Pull Request by adding commits to the branch from which the PR was created.
+
+[Interested in knowing more about about pull requests at Slack?](https://slack.engineering/on-empathy-pull-requests-979e4257d158#.awxtvmb2z)
+
+## Creating a Pull Request
+
+1.  :fork_and_knife: Fork the repository on GitHub.
+2.  :runner: Clone/fetch your fork to your local development machine. It's a good idea to run the tests just
+    to make sure everything is in order.
+3.  :herb: Create a new branch and check it out.
+4.  :crystal_ball: Make your changes and commit them locally. Magic happens here!
+5.  :arrow_heading_up: Push your new branch to your fork. (e.g. `git push username fix-issue-16`).
+6.  :inbox_tray: Open a Pull Request on github.com from your new branch on your fork to `master` in this
+    repository.
+
+## Maintainers
+
+There are more details about processes and workflow in the [Maintainer's Guide](./maintainers_guide.md).

--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -1,0 +1,80 @@
+# Maintainers Guide
+
+This document describes tools, tasks and workflow that one needs to be familiar with in order to effectively maintain
+this project. If you use this package within your own software as is but don't plan on modifying it, this guide is
+**not** for you.
+
+## Tools
+
+All you need to work with this project is a supported version of [Node.js](https://nodejs.org/en/)
+(see [slackapi/bolt](https://github.com/slackapi/bolt-js/) `package.json` field "engines") and npm (which is distributed with Node.js).
+
+## Tasks
+
+### Updating
+
+This package is a dependency for our guides and other example apps.
+When making changes, it's important to keep all of our other guides and apps up-to-date.
+
+When updating this package, please ensure the following are also updated:
+
+- Guides found at [slackapi/bolt-js/docs/](https://github.com/slackapi/bolt-js/tree/main/docs)
+- Example apps at [slackapi/bolt-js/examples/getting-started-*](https://github.com/slackapi/bolt-js/tree/main/examples).
+
+### Testing
+
+This package does not have unit tests but has implemented the command `npm test`.
+
+### Releasing
+
+1.  Create the commit for the release:
+    *  Bump the version number in adherence to [Semantic Versioning](http://semver.org/) in `package.json`.
+    *  Update any dependency versions 
+    *  Confirm tests pass by running `npm test`
+    *  Commit with a message including the new version number. For example `v2.2.0`.
+    *  Tag the commit with the version number. For example `git tag 2.2.0`.
+
+2.  Merge into main repository
+    *  Create a pull request with the commit that was just made. Be certain to include the tag. For
+       example: `git push username main:rel-v1.0.8 && git push --tags username`.
+    *  Once tests pass and a reviewer has approved, merge the pull request. You will also want to
+       update your local `main` branch.
+    *  Push the new tag up to origin `git push --tags origin`.
+
+3.  Distribute the release
+    *  At the moment this package is not distributed on npm.
+    *  It is only downloaded or cloned from GitHub.
+
+4.  (Slack Internal) Communicate the release internally. Include a link to the GitHub Release.
+
+5.  Announce on community.slack.com in #slack-api
+
+## Workflow
+
+### Versioning and Tags
+
+This project is versioned using [Semantic Versioning](http://semver.org/), particularly in the
+[npm flavor](https://docs.npmjs.com/getting-started/semantic-versioning). Each release is tagged
+using git.
+
+### Fork
+
+As a maintainer, the development you do will be almost entirely off of your forked version of this package. The exception to this rule pertains to multiple collaborators working on the same feature, which is detailed in the **Branches** section below.
+
+### Branches
+
+`main` is where active development occurs.
+
+When developing, branches should be created off of your fork and not directly off of this package. If working on a long-running feature and in collaboration with others, a corresponding branch of the same name is permitted. This makes collaboration on a single branch possible, as contributors working on the same feature cannot push commits to others' open Pull Requests.
+
+After a major version increment, there also may be maintenance branches created specifically for supporting older major versions.
+
+### Issue Management
+
+All issues are managed under https://github.com/slackapi/bolt-js/issues.
+
+Use the label `area:examples` to organize issues related to this example app repository.
+
+## Everything else
+
+When in doubt, find the other maintainers and ask.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+###  Summary
+
+Describe the goal of this pull request. Mention any related issue numbers from [slackapi/bolt-js/issues](https://github.com/slackapi/bolt-js/issues).
+
+### Requirements (place an `x` in each `[ ]`)
+
+* [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-js-getting-started-app/blob/main/.github/contributing.md) and have done my best effort to follow them.
+* [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).


### PR DESCRIPTION
###  Summary

In this pull request, we add the `.github/` guides for maintainers, contributors, and pull requests.

It's based on the [Bolt JS GitHub templates](https://github.com/slackapi/bolt-js/tree/main/.github) and has been updated to include details about maintaining the example app.

It does not include the issue template because we redirect developers to [slackapi/bolt-js/issues](https://github.com/slackapi/bolt-js/issues).

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-js-getting-started-app/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).