### PR TITLE
Port is no longer passed into start

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,7 +10,8 @@ see: https://slack.dev/bolt-js/tutorial/getting-started
 const app = new App({
   token: process.env.SLACK_BOT_TOKEN,
   socketMode: true,
-  appToken: process.env.SLACK_APP_TOKEN
+  appToken: process.env.SLACK_APP_TOKEN,
+  port: process.env.PORT || 3000
 });
 
 // Listens to incoming messages that contain "hello"
@@ -46,7 +47,7 @@ app.action('button_click', async ({ body, ack, say }) => {
 
 (async () => {
   // Start your app
-  await app.start(process.env.PORT || 3000);
+  await app.start();
 
   console.log('⚡️ Bolt app is running!');
 })();


### PR DESCRIPTION
###  Summary

This PR fixes an issue with how the app is started where it no longer takes the port number. The port number is instead passed to the constructor

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-js-getting-started-app/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).