### PR TITLE
Add manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,23 @@ responding to events and interactive buttons.
 
 ## Running locally
 
+### 0. Create a new Slack App
+
+- Go to https://api.slack.com/apps
+- Click **Create App**
+- Choose a workspace
+- Enter App Manifest using contents of `manifest.yaml`
+- Click **Create**
+
+Once the app is created click **Install to Workspace** 
+Then scroll down in Basic Info and click **Generate Token and Scopes** with both scopes
+
 ### 1. Setup environment variables
 
 ```zsh
 # Replace with your bot and app token
-export SLACK_BOT_TOKEN=<your-bot-token>
-export SLACK_APP_TOKEN=<your-app-level-token>
+export SLACK_BOT_TOKEN=<your-bot-token> # from the OAuth section
+export SLACK_APP_TOKEN=<your-app-level-token> # from the Basic Info App Token Section
 ```
 
 ### 2. Setup your local project

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ npm install
 npm run start
 ```
 
+### 4. Test
+
+Go to the installed workspace and type **Hello** in a DM to your new bot. You can also type **Hello** in a channel where the bot is present
+
 ## Contributing
 
 ### Issues and questions

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,6 +1,10 @@
 display_information:
   name: Getting Started Bolt App
 features:
+  app_home:
+    home_tab_enabled: false
+    messages_tab_enabled: true
+    messages_tab_read_only_enabled: false
   bot_user:
     display_name: BoltApp
     always_online: true

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,0 +1,25 @@
+display_information:
+  name: Getting Started Bolt App
+features:
+  bot_user:
+    display_name: BoltApp
+    always_online: true
+oauth_config:
+  scopes:
+    bot:
+      - channels:history
+      - channels:join
+      - commands
+      - chat:write
+      - im:history
+settings:
+  event_subscriptions:
+    bot_events:
+      - message.channels
+      - message.im
+  interactivity:
+    is_enabled: true
+  org_deploy_enabled: false
+  socket_mode_enabled: true
+  is_hosted: false
+  token_rotation_enabled: false


### PR DESCRIPTION
###  Summary

Very minor change to expand the manifest explicitly stating that the Messages tab will be enabled and usable to send messages since this is not obvious and could confuse developers given we have the scopes

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-js-getting-started-app/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).