### PR TITLE
Remove "ngrok" from package.json (no longer needed)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Getting Started ⚡️ Bolt for JavaScript",
   "main": "app.js",
   "scripts": {
-    "ngrok": "ngrok http 3000",
     "start": "node app.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
###  Summary

Just a small tweak now that `ngrok` is no longer needed (or mentioned) in this repository with the switch to SocketMode in PR #4

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-js-getting-started-app/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).