### PR TITLE
Deploy the App to Heroku with deploy template

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node app.js

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Go to the installed workspace and type **Hello** in a DM to your new bot. You ca
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/MaurizioBella/bolt-js-getting-started-app)
 
+<img src="deployit_less120sec.gif" width=50% height=50% >
+
 ## Contributing
 
 ### Issues and questions

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ npm run start
 
 Go to the installed workspace and type **Hello** in a DM to your new bot. You can also type **Hello** in a channel where the bot is present
 
+## Deploying to Heroku
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/MaurizioBella/bolt-js-getting-started-app)
+
 ## Contributing
 
 ### Issues and questions

--- a/app.js
+++ b/app.js
@@ -6,12 +6,17 @@ For the companion getting started setup guide,
 see: https://slack.dev/bolt-js/tutorial/getting-started 
 */
 
-// Initializes your app with your bot token and app token
-const app = new App({
-  token: process.env.SLACK_BOT_TOKEN,
-  socketMode: true,
-  appToken: process.env.SLACK_APP_TOKEN
-});
+// Initializes your app with your bot token and app token based on the socket mode setting
+const app = process.env.SOCKET_MODE ? 
+    new App({
+        token: process.env.SLACK_BOT_TOKEN,
+        signingSecret: process.env.SLACK_SIGNING_SECRET
+    }):    
+    new App({
+        token: process.env.SLACK_BOT_TOKEN,
+        socketMode: true,
+        appToken: process.env.SLACK_APP_TOKEN
+    });
 
 // Listens to incoming messages that contain "hello"
 app.message('hello', async ({ message, say }) => {

--- a/app.json
+++ b/app.json
@@ -1,0 +1,45 @@
+{
+    "name": "Getting Started ⚡️ Bolt for JavaScript",
+    "description": "This is a Slack app built with the Bolt for JavaScript framework that showcases responding to events and interactive buttons.",
+    "keywords": [
+      "slack",
+      "nodejs",
+      "bolt",
+      "javascript",
+      "slack api"
+    ],
+    "logo": "https://raw.githubusercontent.com/slackapi/bolt-js/main/docs/assets/bolt-logo.svg",
+    "image": "heroku/nodejs",
+    "website": "https://slack.dev/bolt-js/tutorial/getting-started",
+    "repository": "https://github.com/slackapi/bolt-js-getting-started-app",
+    "success_url": "/",
+    "env": {
+      "SLACK_SIGNING_SECRET": {
+        "description": "Slack creates a unique string for your app and shares it with you. Verify requests from Slack with confidence by verifying signatures using your signing secret. (begins with xoxb-)",
+        "value": "",
+        "required": true
+      },
+      "SLACK_BOT_TOKEN": {
+        "description": "Bot tokens represent a bot associated with the app installed in a workspace. Unlike user tokens, they're not tied to a user's identity; they're just tied to your app.",
+        "value": "",
+        "required": true
+      },
+      "SOCKET_MODE": {
+        "description": "Socket Mode allows your app to use the Events API and interactive components of the platform—without exposing a public HTTP Request URL.",
+        "value": "False",
+        "required": true
+      }
+    },
+    "formation": {
+      "web": {
+        "quantity": 1,
+        "size": "free"
+      }
+    },
+    "buildpacks": [
+      {
+        "url": "heroku/nodejs"
+      }
+    ]
+  }
+  


### PR DESCRIPTION
###  Summary

- Minor change allows users to deploy the app (socket mode off) to Heroku with the deploy template.
- Walkthrough gif on how to configure it in less than 120 seconds.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-js-getting-started-app/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).