### PR TITLE
docs: redirect links towards sdk documentation before clicking

### DIFF
--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -13,7 +13,7 @@ All you need to work with this project is a supported version of [Node.js](https
 
 ### Updating
 
-This package is a dependency for our guides and other example apps. There are many ways to configure a sample app. We prefer to keep a single version of `app.js` which should be consistent with the instructions and code blocks on the [Bolt JS Getting Started guide](https://slack.dev/bolt-js/tutorial/getting-started). This reduces the possibility of drift ocurring between multiple versions. 
+This package is a dependency for our guides and other example apps. There are many ways to configure a sample app. We prefer to keep a single version of `app.js` which should be consistent with the instructions and code blocks on the [Bolt JS Getting Started guide](https://tools.slack.dev/bolt-js/getting-started/). This reduces the possibility of drift ocurring between multiple versions.
 
 When making changes to this repo, it's also important to keep all of our other guides and apps up-to-date.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Getting Started ⚡️ Bolt for JavaScript
+
 > Slack app example from 📚 [Getting started with Bolt for JavaScript tutorial][1]
 
 ## Overview
@@ -16,7 +17,7 @@ responding to events and interactive buttons.
 - Enter App Manifest using contents of `manifest.yaml`
 - Click **Create**
 
-Once the app is created click **Install to Workspace** 
+Once the app is created click **Install to Workspace**
 Then scroll down in Basic Info and click **Generate Token and Scopes** with both scopes
 
 ### 1. Setup environment variables
@@ -41,6 +42,7 @@ npm install
 ```
 
 ### 3. Start servers
+
 ```zsh
 npm run start
 ```
@@ -61,7 +63,7 @@ Found a bug or have a question about this project? We'd love to hear from you!
 
 See you there and thanks for helping to improve Bolt for everyone!
 
-[1]: https://slack.dev/bolt-js/tutorial/getting-started
-[2]: https://slack.dev/bolt-js/
-[3]: https://slack.dev/bolt-js/tutorial/getting-started#setting-up-events
-[4]: https://github.com/slackapi/bolt-js/issues/new
+[1]: https://tools.slack.dev/bolt-js/getting-started
+[2]: https://tools.slack.dev/bolt-js/
+[3]: https://tools.slack.dev/bolt-js/getting-started/#setting-up-events
+[4]: https://github.com/slackapi/bolt-js/issues/new/choose

--- a/app.js
+++ b/app.js
@@ -1,10 +1,10 @@
 const { App } = require('@slack/bolt');
 
-/* 
-This sample slack application uses SocketMode
-For the companion getting started setup guide, 
-see: https://slack.dev/bolt-js/tutorial/getting-started 
-*/
+/**
+ * This sample slack application uses SocketMode.
+ * For the companion getting started setup guide, see:
+ * https://tools.slack.dev/bolt-js/getting-started/
+ */
 
 // Initializes your app with your bot token and app token
 const app = new App({


### PR DESCRIPTION
###  Summary

This PR updates links pointing at `https://slack.dev` to `https://tools.slack.dev` :books: ✨ 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-js-getting-started-app/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).