### PR TITLE
fix: replace the redirected link from slackapi to the slack samples organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ export SLACK_APP_TOKEN=<your-app-level-token> # from the Basic Info App Token Se
 
 ```zsh
 # Clone this project onto your machine
-git clone https://github.com/slackapi/bolt-js-getting-started-app.git
+git clone https://github.com/slack-samples/bolt-js-getting-started-app.git
 
 # Change into the project
 cd bolt-js-getting-started-app/


### PR DESCRIPTION
### Summary

This PR updates the link used to clone this sample to follow the redirection from `slackapi` to this `slack-samples` organization for reduced confusion 🙏 ✨ 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-js-getting-started-app/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
