### PR TITLE
chore: add sample maintainers to the github code owners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Salesforce Open Source project configuration
+# Learn more: https://github.com/salesforce/oss-template
+#ECCN:Open Source
+#GUSINFO:Open Source,Open Source Workflow
+
+# Code owners are the default owners for everything in
+# this repository. The owners listed below will be requested for
+# review when a pull request is opened.
+# To set code owner(s), replace the team below with either
+# their GitHub username(s) or a GitHub team.
+* @slack-samples/maintainers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-404: Not Found#ECCN:Open Source


### PR DESCRIPTION
### Summary

This PR remove an invalid `./CODEOWNERS` file and adds a `.github/CODEOWNERS` file with the `@slack-samples/maintainers team` and required Salesforce comment directives. 👌🏻

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-js-getting-started-app/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
